### PR TITLE
reads state of INPUT pins and sets on update_lines

### DIFF
--- a/custom_components/gpiod/hub.py
+++ b/custom_components/gpiod/hub.py
@@ -124,6 +124,9 @@ class Hub:
             consumer = self.manufacturer,
             config = self._config
         )
+        for port in self._config:
+            if self._config[port].direction == Direction.INPUT:
+                self._entities[port].set(self.update(port))
 
     async def listen(self):
         while True:


### PR DESCRIPTION
I believe this might resolve https://github.com/jdeneef/ha_gpiod/issues/3
Having update_lines read the current state of configured INPUT ports and set it on the entity allows for restarts to detect the current state of things.