### PR TITLE
feat: add bias and drive mode options to switches

### DIFF
--- a/custom_components/gpiod/hub.py
+++ b/custom_components/gpiod/hub.py
@@ -76,7 +76,24 @@ class Hub:
 
         _LOGGER.debug(f"verify_gpiochip gpiodevice: {path} has pinctrl")
         return True
-        
+
+    def _get_bias(self, pull_mode):
+      pull_modes = {
+        "UP": Bias.PULL_UP,
+        "DOWN": Bias.PULL_DOWN,
+        "OFF": Bias.DISABLED,
+        "AS_IS": Bias.AS_IS
+      }
+      return pull_modes.get(pull_mode, Bias.DISABLED)
+
+    def _get_drive(self, drive_mode):
+      drive_modes = {
+        "OPEN_DRAIN": DriveMode.OPEN_DRAIN,
+        "OPEN_SOURCE": DriveMode.OPEN_SOURCE,
+        "PUSH_PULL": DriveMode.PUSH_PULL,
+        "AS_IS": DriveMode.AS_IS
+      }
+      return drive_modes.get(drive_mode, DriveMode.PUSH_PULL)
 
     def startup(self, _):
         """Stuff to do after starting."""
@@ -141,12 +158,14 @@ class Hub:
                     _LOGGER.debug(f"Event: {event}")
                     self._entities[event.line_offset].update()
 
-    def add_switch(self, entity, port, invert_logic) -> None:
+    def add_switch(self, entity, port, invert_logic, bias=None, drive=None) -> None:
         _LOGGER.debug(f"in add_switch {port}")
         self._entities[port] = entity
         self._config[port].direction = Direction.OUTPUT
         self._config[port].output_value = Value.INACTIVE
         self._config[port].active_low = invert_logic
+        self._config[port].bias = self._get_bias(bias)
+        self._config[port].drive_mode = self._get_drive(drive)
 
     def turn_on(self, port) -> None:
         _LOGGER.debug(f"in turn_on")

--- a/custom_components/gpiod/switch.py
+++ b/custom_components/gpiod/switch.py
@@ -12,6 +12,10 @@ from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
 from homeassistant.const import CONF_SWITCHES, CONF_NAME, CONF_PORT, CONF_UNIQUE_ID
 CONF_INVERT_LOGIC="invert_logic"
 DEFAULT_INVERT_LOGIC = False
+CONF_BIAS="bias"
+DEFAULT_BIAS = "UP"
+CONF_DRIVE_MODE="drive_mode"
+DEFAULT_DRIVE_MODE = "PUSH_PULL"
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
@@ -25,6 +29,8 @@ PLATFORM_SCHEMA = vol.All(
                     vol.Required(CONF_PORT): cv.positive_int,
                     vol.Optional(CONF_UNIQUE_ID): cv.string,
                     vol.Optional(CONF_INVERT_LOGIC, default=DEFAULT_INVERT_LOGIC): cv.boolean
+                    vol.Optional(CONF_BIAS, default=DEFAULT_BIAS): cv.string,
+                    vol.Optional(CONF_DRIVE_MODE, default=DEFAULT_DRIVE_MODE): cv.string
                 }]
             )
         }
@@ -61,15 +67,17 @@ async def async_setup_platform(
 class GPIODSwitch(SwitchEntity):
     should_poll = False
 
-    def __init__(self, hub, name, port, unique_id, invert_logic):
-        _LOGGER.debug(f"GPIODSwitch init: {port} - {name} - {unique_id}")
+    def __init__(self, hub, name, port, unique_id, invert_logic, bias, drive_mode):
+        _LOGGER.debug(f"GPIODSwitch init: {port} - {name} - {unique_id} - invert_logic: {invert_logic} - bias: {bias} - drive_mode: {drive_mode}")
         self._hub = hub
         self._attr_name = name
         self._port = port
         self._attr_unique_id = unique_id
         self._invert_logic = invert_logic
+        self._bias = bias
+        self._drive_mode = drive_mode
         self._is_on = False != invert_logic
-        hub.add_switch(self, port, invert_logic)
+        hub.add_switch(self, port, invert_logic, bias, drive_mode)
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
Hello,

Yesterday I struggled big time to power a relay from a raspi 4. Until I figured via the CLI that I needed no bias, and open drain drive mode. 
Those options werent present so, here we are !

Let me know if you need anything else. It's barely tested right now, gonna deploy it today and get back here tomorrow with feedback ! 