### PR TITLE
Add the option to have persistent switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ switch:
         port: 11
         bias: "AS_IS"
         drive: "PUSH_PULL"
-      - name: "Buzzer"
+      - name: "Fan"
         port: 8
         persistent: true
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ switch:
         drive: "PUSH_PULL"
       - name: "Buzzer"
         port: 8
+        persistent: true
 
 # Example of binary_sensor (eg push button) setup
 binary_sensor:
@@ -107,6 +108,7 @@ Key | Required | Default | Type | Description
 `bias` | no | `AS_IS` | string  | Type of internal pull resistor to use: `PULL_UP` - pull-up resistor, `PULL_DOWN` - pull-down resistor, `AS-IS` no change
 `pull_mode`|*backwards compatibility*| |string|see `bias`, might be removed in the future
 `drive`|no| `PUSH_PULL`|string | control drive configuration of the GPIO, determines how the line behaves when it is set to output mode; `PUSH_PULL`, GPIO line can both source and sink current, can actively drive the line to both high and low states. `OPEN-DRAIN`, GPPIO can only sink current (drive the line to low) and is otherwise left floating, and `OPEN-SOURCE` the reverse.
+`persistent` | no | `false` | boolean | If true, the switch state will be persistent in HA and will be restored if HA restart / crash.
 
 ## Cover
 

--- a/custom_components/gpiod/hub.py
+++ b/custom_components/gpiod/hub.py
@@ -97,9 +97,6 @@ class Hub:
         if not self._online:
             return
 
-        # setup lines
-        self.update_lines()
-
         # read initial states for sensors
         for port in self._config:
             self._entities[port].update()
@@ -163,6 +160,7 @@ class Hub:
             active_low = active_low,
             output_value = Value.ACTIVE if value ^ active_low else Value.INACTIVE,
         )
+        self.update_lines()
 
     def turn_on(self, port) -> None:
         _LOGGER.debug(f"in turn_on")
@@ -191,6 +189,7 @@ class Hub:
             output_value = Value.ACTIVE if value ^ active_low else Value.INACTIVE,
         )
         self._edge_events = True
+        self.update_lines()
 
     def update(self, port, **kwargs):
         return self._lines.get_value(port) == Value.ACTIVE
@@ -200,4 +199,5 @@ class Hub:
         _LOGGER.debug(f"in add_cover {relay_port} {state_port}")
         self.add_switch(entity, relay_port, relay_active_low, relay_bias, relay_drive)
         self.add_sensor(entity, state_port, state_active_low, state_bias, 50)
+        self.update_lines()
 


### PR DESCRIPTION
Add new GPIO switch class - PersistentRPiGPIOSwitch which will restore the switch state after Home Assistant restart.
As part of the change move the core switch to use async functions

This is based on my work in the original branch: https://github.com/thecode/ha-rpi_gpio/pull/266